### PR TITLE
Add gh-pages CI

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -4,7 +4,7 @@ name: Vite CI to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['pages-test']
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,55 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Vite CI to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['pages-test']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+          # specify client directory lock file
+          # https://stackoverflow.com/questions/68639588/github-actions-dependencies-lock-file-is-not-found-in-runners-path
+      - name: Install dependencies and build
+        run: |
+          cd client
+          npm install
+          npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload dist repository
+          path: './client/dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://coc-acm-tech-club.github.io/clubwebsite/",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,11 +1,6 @@
-import { useState } from "react";
 import {
-  BrowserRouter as Router,
-  createBrowserRouter,
+  createHashRouter,
   RouterProvider,
-  Routes,
-  Route,
-  Link,
 } from "react-router-dom";
 import Foot from "../src/components/Footer/Foot.tsx";
 import "./App.css";
@@ -15,7 +10,7 @@ import Projects from './components/Projects/Projects.tsx';
 import Events from './components/Events/Events.tsx';
 
 // Add new paths here!
-const router = createBrowserRouter([
+const router = createHashRouter([
   { path: "/", element: <HomePage /> },
   { path: "/projects", element: <Projects /> },
   { path: "/events", element: <Events />},

--- a/client/src/components/Events/Events.tsx
+++ b/client/src/components/Events/Events.tsx
@@ -1,11 +1,12 @@
-import React from 'react'
+import React from 'react';
 
-import "./Events.css"
-import EventsCard from "./EventsCard.tsx"
+import "./Events.css";
+import EventsCard from "./EventsCard.tsx";
 import * as eventsJSON from "./events.json";
 
 const Events: React.FC = () => {
     const event_list = eventsJSON.events;
+    window.scrollTo(0,0);
     return (
         <div className="EventsPage">
             <h1 className="EventTitle">EVENTS & ANNOUNCEMENTS</h1>

--- a/client/src/components/Footer/Foot.tsx
+++ b/client/src/components/Footer/Foot.tsx
@@ -26,7 +26,7 @@ const Foot: React.FC = () => {
         <section style={{ display: "flex", flexDirection: "row", gap: 10 }}>
           {tabs.map((tab) => {
             return (
-              <a href={tab.path} className="NavItems" key={tab.name}>
+              <a href={"/clubwebsite/#" + tab.path} className="NavItems" key={tab.name}>
                 {tab.name}
               </a>
             );

--- a/client/src/components/HomePage/HomePage.tsx
+++ b/client/src/components/HomePage/HomePage.tsx
@@ -7,6 +7,7 @@ import WhatWeDo from './components/WhatWeDo'
 
 
 const HomePage: React.FC = () => {
+    window.scrollTo(0,0);
     return (
         <div>
             <Welcome/>

--- a/client/src/components/Projects/Projects.tsx
+++ b/client/src/components/Projects/Projects.tsx
@@ -6,6 +6,7 @@ import * as projectsJSON from "./projects.json";
 
 const Projects: React.FC = () => {
     const projects = projectsJSON.projects;
+    window.scrollTo(0,0);
     return (
         <div className="Projects">
             {projects.map((project, index) => (

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react-swc'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/clubwebsite/',
 })


### PR DESCRIPTION
Implements CI for npm builds on gh-pages through gh-actions on push. Replaces BrowserRouter with HashRouter as gh-pages only serves single static pages and routing 404.html to index.html is finnicky. Also fixes header paths to work with the new routing.